### PR TITLE
adjust the aws account matrix

### DIFF
--- a/.github/workflows/reusable_deploy_aws_accounts.yaml
+++ b/.github/workflows/reusable_deploy_aws_accounts.yaml
@@ -80,12 +80,32 @@ permissions:
   id-token: write
 
 jobs:
+  setup-matrix:
+    name: setup matrix
+    runs-on: ubuntu-latest
+    outputs:
+      accounts: ${{ steps.set-accounts.outputs.accounts }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - id: set-accounts
+        env:
+          AWS_ACCOUNT_INPUT: ${{ inputs.aws_account }}
+        run: |
+          set -euo pipefail
+          if [ "$AWS_ACCOUNT_INPUT" = "all" ]; then
+            accounts="$(find terragrunt/aws -mindepth 1 -maxdepth 1 -type d -printf '%f\n' | sort | jq -R . | jq -sc .)"
+          else
+            accounts="$(jq -cn --arg a "$AWS_ACCOUNT_INPUT" '[$a]')"
+          fi
+          echo "accounts=$accounts" >> "$GITHUB_OUTPUT"
+
   deploy-aws-accounts:
     name: ${{ matrix.aws_account }}
+    needs: setup-matrix
     strategy:
       fail-fast: false
       matrix:
-        aws_account: ${{ fromJson(inputs.aws_account == 'all' && '["green","purple","mgmt"]' || format('["{0}"]', inputs.aws_account)) }}
+        aws_account: ${{ fromJson(needs.setup-matrix.outputs.accounts) }}
     uses: ./.github/workflows/reusable_deploy_aws_regions.yaml
     with:
       aws_account: ${{ matrix.aws_account }}


### PR DESCRIPTION
## Summary

Replaces the hardcoded `["green","purple","mgmt"]` matrix in `reusable_deploy_aws_accounts.yaml` with a dynamic matrix that is built at runtime by inspecting the `terragrunt/aws/` directory.

## Changes

- Added a new `setup-matrix` job that runs before `deploy-aws-accounts`
  - When `inputs.aws_account == "all"`: checks out the repo and uses `find` to list all subdirectories under `terragrunt/aws/`, producing a sorted JSON array
  - When `inputs.aws_account != "all"`: uses `jq --arg` to safely wrap the single account name in a JSON array
- Updated `deploy-aws-accounts` to depend on `setup-matrix` and consume its `accounts` output as the matrix source
- Removed the inline ternary expression that hardcoded the account list
- Hardened the shell script against injection: `inputs.aws_account` is passed via an `env` variable (`AWS_ACCOUNT_INPUT`) rather than interpolated directly into the script, and `jq --arg` is used to safely construct the JSON in the single-account case
- Added `set -euo pipefail` for safer shell execution

## Why

Previously, adding or removing an AWS account required manually updating the hardcoded array in this workflow. Now, adding or removing a directory under `terragrunt/aws/` is sufficient — the next run with `all` selected will automatically pick up the change.