### PR TITLE
adjust the aws region matrix

### DIFF
--- a/.github/workflows/reusable_deploy_aws_regions.yaml
+++ b/.github/workflows/reusable_deploy_aws_regions.yaml
@@ -79,12 +79,33 @@ permissions:
   id-token: write
 
 jobs:
+  setup-matrix:
+    name: setup matrix
+    runs-on: ubuntu-latest
+    outputs:
+      regions: ${{ steps.set-regions.outputs.regions }}
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - id: set-regions
+        env:
+          AWS_ACCOUNT_INPUT: ${{ inputs.aws_account }}
+          AWS_REGION_INPUT: ${{ inputs.aws_region }}
+        run: |
+          set -euo pipefail
+          if [ "$AWS_REGION_INPUT" = "all" ]; then
+            regions="$(find "terragrunt/aws/$AWS_ACCOUNT_INPUT" -mindepth 1 -maxdepth 1 -type d -exec basename {} \; | sort | jq -R . | jq -sc .)"
+          else
+            regions="$(jq -cn --arg r "$AWS_REGION_INPUT" '[$r]')"
+          fi
+          echo "regions=$regions" >> "$GITHUB_OUTPUT"
+
   deploy-aws-regions:
     name: ${{ matrix.aws_region }}
+    needs: setup-matrix
     strategy:
       fail-fast: false
       matrix:
-        aws_region: ${{ fromJson(inputs.aws_region == 'all' && '["_global","ca-central-1","us-east-1","us-east-2"]' || format('["{0}"]', inputs.aws_region)) }}
+        aws_region: ${{ fromJson(needs.setup-matrix.outputs.regions) }}
     uses: ./.github/workflows/reusable_terragrunt_action.yaml
     with:
       aws_region: ${{ matrix.aws_region }}


### PR DESCRIPTION
## Summary

Replaces the hardcoded `["_global","ca-central-1","us-east-1","us-east-2"]` matrix in `reusable_deploy_aws_regions.yaml` with a dynamic matrix that is built at runtime by inspecting the `terragrunt/aws/<account>/` directory.

## Changes

- Added a new `setup-matrix` job that runs before `deploy-aws-regions`
  - When `inputs.aws_region == "all"`: checks out the repo and uses `find` to list all subdirectories under `terragrunt/aws/$AWS_ACCOUNT_INPUT/`, producing a sorted JSON array
  - When `inputs.aws_region != "all"`: uses `jq --arg` to safely wrap the single region name in a JSON array
- Updated `deploy-aws-regions` to depend on `setup-matrix` and consume its `regions` output as the matrix source
- Removed the inline ternary expression that hardcoded the region list
- Hardened the shell script against injection: both `inputs.aws_account` and `inputs.aws_region` are passed via `env` variables rather than interpolated directly into the script, and `jq --arg` is used to safely construct the JSON in the single-region case
- Added `set -euo pipefail` for safer shell execution

## Why

Previously, adding or removing a region required manually updating the hardcoded array in this workflow. Now, adding or removing a directory under `terragrunt/aws/<account>/` is sufficient — the next run with `all` selected will automatically pick up the change.

Each account's regions are discovered independently, so accounts can diverge in their region sets over time without any workflow changes.