### PR TITLE
refactor terraform-docs to trigger on push to main

### DIFF
--- a/.github/workflows/_terraform_docs.yaml
+++ b/.github/workflows/_terraform_docs.yaml
@@ -1,19 +1,21 @@
 name: _terraform-docs
-run-name: "terraform-docs: ${{ github.event_name == 'pull_request' && github.event.pull_request.title || github.ref_name }}"
+run-name: "terraform-docs: ${{ github.ref_name }}"
 
 on:
-  pull_request:
+  push:
     branches:
       - main
     paths:
       - 'terraform/modules/**'
-    types:
-      - opened
-      - reopened
-      - synchronize
+  workflow_dispatch: {}
 
 permissions:
   contents: write
+  pull-requests: write
+
+concurrency:
+  group: terraform-docs-${{ github.ref_name }}
+  cancel-in-progress: false
 
 jobs:
   terraform-docs:


### PR DESCRIPTION
## Why

Renovate stops rebasing/updating a PR it opened once it detects a commit from
someone/something else on that PR's branch. The old `_terraform-docs`
trigger (`pull_request` on `terraform/modules/**`) ran `terraform-docs` with
`git-push: true` directly onto whatever PR opened it - including Renovate's
own PRs - which made Renovate flag them as "edited" and abandon further
updates.

## What changed

- Trigger swapped from `pull_request` (opened/reopened/synchronize) to
  `push` on `main` for the same `terraform/modules/**` paths, plus a manual
  `workflow_dispatch` backstop. terraform-docs now runs *after* a PR merges
  to `main`, against the resulting merge commit, instead of before/during
  review.
- Added `pull-requests: write` permission - the reusable workflow now opens
  its own follow-up PR with any generated doc changes instead of committing
  back to the triggering branch (see
  [ulfiac/commons#107](https://github.com/ulfiac/commons/pull/107), already
  merged).
- Simplified `run-name` (no longer needs the `pull_request` fallback).

## Effect

Renovate PRs touching `terraform/modules/**` merge cleanly with no bot
commits added to them. If merging changes the generated docs, a separate
`terraform-docs-updates/main` PR is opened/updated afterward instead.

## Related

- [ulfiac/commons#107](https://github.com/ulfiac/commons/pull/107) - reusable
  workflow changes this depends on (merged)
- Companion PR in `ulfiac/aws-bootstrap` applies the same trigger change
