### PR TITLE
adjust trigger for terraform-docs workflow

### DIFF
--- a/.github/workflows/_terraform_docs.yaml
+++ b/.github/workflows/_terraform_docs.yaml
@@ -7,6 +7,7 @@ on:
       - main
     paths:
       - 'terraform/modules/**'
+      - '!terraform/modules/**/README.md'
   workflow_dispatch: {}
 
 permissions:


### PR DESCRIPTION
## Why

After merge, `_terraform-docs.yaml` triggers on `push` to `main` for changes
under `terraform/modules/**` and (when docs drifted) opens its own follow-up
PR containing the regenerated `README.md` files. Since that follow-up PR only
ever changes `README.md` files under `terraform/modules/**`, merging it back
into `main` matched the same path filter and re-triggered the workflow again
- a harmless but wasteful extra run every time.

## What changed

Added a negated path pattern to exclude `README.md` changes from the trigger:

```yaml
paths:
  - 'terraform/modules/**'
  - '!terraform/modules/**/README.md'
```

Per GitHub's path filter rules, a push is only excluded from triggering the
workflow if *all* of its changed files match a negated pattern. So:
- A merge that only changes `README.md` files (i.e. the docs-update PR
  merging back into `main`) no longer triggers the workflow.
- A merge that changes any `.tf` file still triggers normally, even if it
  also happens to touch a `README.md` (e.g. a human hand-editing docs
  alongside a real change).
