### PR TITLE
add public subnets to eks_vpc module

### DIFF
--- a/terraform/modules/eks_vpc/data.tf
+++ b/terraform/modules/eks_vpc/data.tf
@@ -1,7 +1,4 @@
-data "aws_availability_zones" "available" {
-  state = "available"
-}
-
-# data "aws_caller_identity" "current" {}
+# no state filter: keep the full, stable AZ list so transient AZ health doesn't reshuffle subnet identity
+data "aws_availability_zones" "all" {}
 
 data "aws_region" "current" {}

--- a/terraform/modules/eks_vpc/data.tf
+++ b/terraform/modules/eks_vpc/data.tf
@@ -1,4 +1,10 @@
 # no state filter: keep the full, stable AZ list so transient AZ health doesn't reshuffle subnet identity
-data "aws_availability_zones" "all" {}
+# opt-in-status filter excludes Local/Wavelength Zones, whose names can sort before regular AZ names
+data "aws_availability_zones" "all" {
+  filter {
+    name   = "opt-in-status"
+    values = ["opt-in-not-required"]
+  }
+}
 
 data "aws_region" "current" {}

--- a/terraform/modules/eks_vpc/main.tf
+++ b/terraform/modules/eks_vpc/main.tf
@@ -1,7 +1,7 @@
 locals {
 
   # sort availability_zones
-  availability_zones_sorted = sort(data.aws_availability_zones.available.names)
+  availability_zones_sorted = sort(data.aws_availability_zones.all.names)
 
   # select the first N based on availability_zone_count
   availability_zones_first_n = slice(local.availability_zones_sorted, 0, min(var.availability_zone_count, length(local.availability_zones_sorted)))
@@ -11,5 +11,16 @@ locals {
 
   igw_name = "${var.namespace}-${local.aws_region}"
   vpc_name = "${var.namespace}-${local.aws_region}"
+
+  # prefix length of the block being carved up into public subnets
+  public_cidr_block_prefix = tonumber(split("/", var.public_cidr_block)[1])
+
+  # additional bits needed to go from the parent block to the desired public_subnet_mask
+  public_subnet_newbits = var.public_subnet_mask - local.public_cidr_block_prefix
+
+  # one public subnet per selected availability zone, keyed by AZ name for stable addressing
+  public_subnets = {
+    for idx, az in local.availability_zones_first_n : az => idx
+  }
 
 }

--- a/terraform/modules/eks_vpc/main.tf
+++ b/terraform/modules/eks_vpc/main.tf
@@ -13,14 +13,18 @@ locals {
   vpc_name = "${var.namespace}-${local.aws_region}"
 
   # prefix length of the block being carved up into public subnets
-  public_cidr_block_prefix = tonumber(split("/", var.public_cidr_block)[1])
+  public_cidr_block_prefix = try(tonumber(split("/", var.public_cidr_block)[1]), null)
 
   # additional bits needed to go from the parent block to the desired public_subnet_mask
-  public_subnet_newbits = var.public_subnet_mask - local.public_cidr_block_prefix
+  public_subnet_newbits = try(var.public_subnet_mask - local.public_cidr_block_prefix, null)
+
+  # false when public_cidr_block/public_subnet_mask are malformed; variable validation already
+  # reports that case, so no public subnets are planned rather than crashing on garbage inputs
+  public_cidr_valid = local.public_subnet_newbits != null && can(cidrsubnet(var.public_cidr_block, local.public_subnet_newbits, 0))
 
   # one public subnet per selected availability zone, keyed by AZ name for stable addressing
-  public_subnets = {
+  public_subnets = local.public_cidr_valid ? {
     for idx, az in local.availability_zones_first_n : az => idx
-  }
+  } : {}
 
 }

--- a/terraform/modules/eks_vpc/outputs.tf
+++ b/terraform/modules/eks_vpc/outputs.tf
@@ -1,6 +1,11 @@
-output "data_availability_zones_available" {
-  description = "The available AWS availability zones data source"
-  value       = var.verbose_output ? data.aws_availability_zones.available : null
+output "data_availability_zones_all" {
+  description = "All AWS availability zones the account has access to (unfiltered by state)"
+  value       = var.verbose_output ? data.aws_availability_zones.all : null
+}
+
+output "data_aws_region_current" {
+  description = "The current AWS region data source"
+  value       = var.verbose_output ? data.aws_region.current : null
 }
 
 output "local_availability_zones_first_n" {
@@ -13,9 +18,29 @@ output "local_availability_zones_sorted" {
   value       = var.verbose_output ? local.availability_zones_sorted : null
 }
 
-output "data_aws_region_current" {
-  description = "The current AWS region data source"
-  value       = var.verbose_output ? data.aws_region.current : null
+output "local_public_subnets" {
+  description = "Map of availability zone to CIDR sub-block index used to carve each public subnet"
+  value       = var.verbose_output ? local.public_subnets : null
+}
+
+output "local_public_cidr_block_prefix" {
+  description = "The prefix length of the parent public_cidr_block (not the carved subnets' prefix)"
+  value       = var.verbose_output ? local.public_cidr_block_prefix : null
+}
+
+output "local_public_subnet_newbits" {
+  description = "The number of new bits for the local public subnets"
+  value       = var.verbose_output ? local.public_subnet_newbits : null
+}
+
+output "public_route_table_id" {
+  description = "The ID of the shared public route table"
+  value       = aws_route_table.public.id
+}
+
+output "public_subnet_ids" {
+  description = "Map of availability zone to public subnet ID"
+  value       = { for az, subnet in aws_subnet.public : az => subnet.id }
 }
 
 output "vpc_id" {

--- a/terraform/modules/eks_vpc/public_route_table.tf
+++ b/terraform/modules/eks_vpc/public_route_table.tf
@@ -1,0 +1,20 @@
+resource "aws_route_table" "public" {
+  vpc_id = aws_vpc.vpc.id
+
+  tags = {
+    Name = "${var.namespace}-public"
+  }
+}
+
+resource "aws_route" "public_internet_gateway" {
+  destination_cidr_block = "0.0.0.0/0"
+  gateway_id             = aws_internet_gateway.igw.id
+  route_table_id         = aws_route_table.public.id
+}
+
+resource "aws_route_table_association" "public" {
+  for_each = aws_subnet.public
+
+  route_table_id = aws_route_table.public.id
+  subnet_id      = each.value.id
+}

--- a/terraform/modules/eks_vpc/public_subnets.tf
+++ b/terraform/modules/eks_vpc/public_subnets.tf
@@ -1,0 +1,13 @@
+resource "aws_subnet" "public" {
+  for_each = local.public_subnets
+
+  availability_zone       = each.key
+  cidr_block              = cidrsubnet(var.public_cidr_block, local.public_subnet_newbits, each.value)
+  map_public_ip_on_launch = false
+  vpc_id                  = aws_vpc.vpc.id
+
+  tags = {
+    Name                     = "${var.namespace}-public-${each.key}"
+    "kubernetes.io/role/elb" = "1"
+  }
+}

--- a/terraform/modules/eks_vpc/variables.tf
+++ b/terraform/modules/eks_vpc/variables.tf
@@ -14,23 +14,50 @@ variable "namespace" {
   type        = string
 }
 
-# variable "enable_public_subnets" {
-#   description = "Enable or disable the creation of public subnets."
-#   type        = bool
-#   default     = true
-# }
+variable "public_cidr_block" {
+  description = "The CIDR block to carve up into public subnets, one per availability zone."
+  type        = string
 
-# variable "enable_private_subnets" {
-#   description = "Enable or disable the creation of private subnets."
-#   type        = bool
-#   default     = true
-# }
+  validation {
+    condition     = can(cidrhost(var.public_cidr_block, 0))
+    error_message = "Must be a valid IPv4 CIDR block format."
+  }
 
-# variable "enable_isolated_subnets" {
-#   description = "Enable or disable the creation of isolated subnets."
-#   type        = bool
-#   default     = true
-# }
+  validation {
+    condition = try(
+      tonumber(split("/", var.public_cidr_block)[1]) >= tonumber(split("/", var.vpc_cidr_block)[1]) &&
+      cidrhost(var.vpc_cidr_block, 0) == cidrhost("${cidrhost(var.public_cidr_block, 0)}/${split("/", var.vpc_cidr_block)[1]}", 0),
+      false
+    )
+    error_message = "public_cidr_block must be contained within vpc_cidr_block."
+  }
+}
+
+variable "public_subnet_mask" {
+  description = "The subnet mask (prefix length) used when carving public_cidr_block into individual public subnets, e.g. 24 for a /24."
+  type        = number
+
+  validation {
+    condition = try(
+      var.public_subnet_mask > tonumber(split("/", var.public_cidr_block)[1]) &&
+      can(cidrsubnet(var.public_cidr_block, var.public_subnet_mask - tonumber(split("/", var.public_cidr_block)[1]), 0)),
+      false
+    )
+    error_message = "Must be a valid prefix length (1-32) that is strictly more specific than public_cidr_block."
+  }
+
+  # AWS allows a public subnet to be between /16 and /28
+  # AWS requires ALB subnets to be /27 or larger (a /28 only has 11 usable IPs after AWS's reserved 5)
+  validation {
+    condition     = var.public_subnet_mask >= 16 && var.public_subnet_mask <= 27
+    error_message = "public_subnet_mask must be between 16 and 27; these subnets are ALB-only and AWS requires /27 or larger for ALB subnets."
+  }
+
+  validation {
+    condition     = try(pow(2, var.public_subnet_mask - tonumber(split("/", var.public_cidr_block)[1])) >= var.availability_zone_count, false)
+    error_message = "public_subnet_mask must be small enough to carve out at least availability_zone_count sub-blocks from public_cidr_block."
+  }
+}
 
 variable "verbose_output" {
   description = "Enable verbose output for debugging purposes."

--- a/terraform/modules/eks_vpc/variables.tf
+++ b/terraform/modules/eks_vpc/variables.tf
@@ -2,6 +2,12 @@ variable "availability_zone_count" {
   description = "The number of availability zones to use for the VPC."
   type        = number
   default     = 3
+
+  # these subnets are ALB-only, and AWS requires ALB subnets to span at least 2 AZs
+  validation {
+    condition     = var.availability_zone_count == floor(var.availability_zone_count) && var.availability_zone_count >= 2
+    error_message = "availability_zone_count must be a whole number of at least 2."
+  }
 }
 
 variable "log_bucket_arn" {

--- a/terragrunt/aws/mgmt/us-east-2/eks_vpc/terragrunt.hcl
+++ b/terragrunt/aws/mgmt/us-east-2/eks_vpc/terragrunt.hcl
@@ -16,8 +16,10 @@ dependency "log_bucket" {
 }
 
 inputs = {
-  log_bucket_arn = dependency.log_bucket.outputs.log_bucket_arn
-  namespace      = "eks"
-  verbose_output = true
-  vpc_cidr_block = "10.2.0.0/16"
+  log_bucket_arn     = dependency.log_bucket.outputs.log_bucket_arn
+  namespace          = "eks"
+  public_cidr_block  = "10.1.32.0/21"
+  public_subnet_mask = 23
+  verbose_output     = true
+  vpc_cidr_block     = "10.1.32.0/19" # region block 2 of 8: 10.1.0.0/16 split into 8 /19s
 }


### PR DESCRIPTION
## What

Adds public subnets and their routing to the `eks_vpc` terraform module.

- `aws_subnet.public` (`public_subnets.tf`): one subnet per availability zone, carved out of a new `public_cidr_block` input using `public_subnet_mask`. Subnets are `for_each`-keyed by AZ name for stable resource addressing (not `count`-indexed), `map_public_ip_on_launch` is deliberately `false` — only ALBs placed in these subnets should get public IPs, not anything by default — and subnets are tagged `kubernetes.io/role/elb = 1` so the AWS Load Balancer Controller can auto-discover them for internet-facing ALBs.
- `aws_route_table.public` + a default `0.0.0.0/0` route to the IGW + associations for every public subnet (`public_route_table.tf`).
- New variables: `public_cidr_block` (validated as a well-formed CIDR that's fully contained within `vpc_cidr_block`), `public_subnet_mask` (validated to be strictly more specific than `public_cidr_block`, between `/16` and `/27` — capped at `/27` rather than AWS's general `/28` subnet floor, since these subnets are ALB-only and AWS requires `/27` or larger for ALB subnets — and small enough to carve out at least `availability_zone_count` sub-blocks). Cross-variable checks are guarded with `try(..., false)` so a malformed CIDR fails validation cleanly instead of raising a raw expression error.
- New outputs: `public_route_table_id`, `public_subnet_ids` (map of AZ → subnet ID), plus `verbose_output`-gated locals for debugging (`local_public_subnets`, `local_public_cidr_block_prefix`, `local_public_subnet_newbits`).
- `data.aws_availability_zones` (`data.tf`) no longer filters by `state = "available"` and is renamed from `available` to `all`. That filter isn't AWS's default and made the AZ list — and therefore subnet identity and `cidr_block` assignment — sensitive to *transient* AZ health: if an AZ were briefly reported impaired, it would drop out of the list, get its subnet destroyed, and shift the CIDR index of every other public subnet, forcing them to be replaced too. Dropping the filter restores AWS's default stable/complete AZ list for the account.

## `mgmt/us-east-2` addressing

This account's `10.1.0.0/16` is being split into 8 `/19` blocks, one per region; `us-east-2` gets block 2 of 8 (`10.1.32.0/19`). Within that `/19`, the first `/21` (`10.1.32.0/21`, split into `/23`s per AZ) goes to public subnets; the remaining three `/21`s are reserved for private, isolated, and spare. `vpc_cidr_block` in `terragrunt/aws/mgmt/us-east-2/eks_vpc/terragrunt.hcl` changes accordingly from `10.2.0.0/16` to `10.1.32.0/19` — safe to do here since this module hasn't been deployed yet.

The public `/21` currently only allocates 3 of its 4 `/23` blocks (`availability_zone_count` defaults to 3, matching `us-east-2`'s 3 AZs), leaving headroom for a 4th AZ if ever needed.

## Follow-up (not in this PR)

- Private and isolated subnets, using the same `{tier}_cidr_block` / `{tier}_subnet_mask` variable pattern established here, will be required (not conditional) inputs added in a future PR.
- Public subnets aren't yet tagged with `kubernetes.io/cluster/<cluster-name> = shared`, since this module doesn't have a cluster-name input — worth revisiting once the EKS cluster module is wired up to this one.
- Even after this fix, a permanent AWS-side AZ addition/removal from the account could still shift CIDR indices. Considered acceptable for now since that's a rare, deliberate, slow-moving change that would surface in a normal reviewed `plan`, not during an unattended apply — a fully pinned/explicit AZ list input remains an option if stronger guarantees are ever needed.
