### PR TITLE
add request-copilot-review workflow

### DIFF
--- a/.github/workflows/_request_copilot_review.yaml
+++ b/.github/workflows/_request_copilot_review.yaml
@@ -1,0 +1,21 @@
+name: _request_copilot_review
+run-name: "_request_copilot_review: ${{ github.event.pull_request.title }}"
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+
+concurrency:
+  group: request-copilot-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions: {}
+
+jobs:
+  reusable-request-copilot-review:
+    uses: ulfiac/commons/.github/workflows/reusable_request_copilot_review.yaml@86b40df45927518a32a965cb22175452e51d5129 # v1.0.36
+    secrets:
+      PAT_REQUEST_COPILOT_REVIEW: ${{ secrets.PAT_REQUEST_COPILOT_REVIEW }}


### PR DESCRIPTION
## Problem

Bot-authored PRs (Renovate) in this repo don't get an automatic Copilot code review, since GitHub's automatic-review trigger only fires for PRs opened by a user with Copilot access, not a bot/App identity.

## Fix

Add `_request_copilot_review.yaml`, calling the `reusable_request_copilot_review.yaml` reusable workflow from `commons` (pinned to v1.0.36), which explicitly requests a Copilot review via `gh pr edit --add-reviewer @copilot` whenever a bot-authored PR is opened, reopened, or updated (`synchronize`). Gated on `github.event.pull_request.user.type == 'Bot'` so human-authored PRs are unaffected. A concurrency group (keyed on PR number, `cancel-in-progress: true`) avoids piling up redundant requests when a PR gets updated multiple times in quick succession.

This uses a fine-grained PAT (`PAT_REQUEST_COPILOT_REVIEW`, "Pull requests: Read and write" only) instead of the default `GITHUB_TOKEN`, since testing in `commons` proved the default token silently fails to register a Copilot review request -- only a token from an account with actual Copilot access works. **This repo secret still needs to be added** before this workflow will work; see the parallel manual setup steps.

`permissions: {}` is set explicitly, since the actual mutating call authenticates entirely via the PAT (`GH_TOKEN: ${{ secrets.PAT_REQUEST_COPILOT_REVIEW }}`) and never touches `GITHUB_TOKEN`. This repo's default workflow token permissions are "read," so an omitted `permissions:` block would still grant unnecessary ambient read access across contents/issues/pull-requests/etc.; `{}` is the only way to get to true zero access, and stays correct even if the repo's default permissions setting changes later.

## Note

Unlike `containers`, this PR does **not** enable Renovate `automerge` for anything here. Given `infra` manages real AWS accounts/IAM, we're deliberately keeping automerge scoped narrowly and starting only with `containers`. Also worth tracking separately: `infra/terraform/modules/repo/main.tf` manages a `github_repository_ruleset` (`required_approving_review_count = 0`) that doesn't yet reflect the hand-added "require 1 approver" ruleset changes being rolled out -- needs reconciling before that module is next applied to avoid drift.