### PR TITLE
zero-out permissions in terraform-docs workflow

### DIFF
--- a/.github/workflows/_terraform_docs.yaml
+++ b/.github/workflows/_terraform_docs.yaml
@@ -10,9 +10,7 @@ on:
       - '!terraform/modules/**/README.md'
   workflow_dispatch: {}
 
-permissions:
-  contents: write
-  pull-requests: write
+permissions: {}
 
 jobs:
   terraform-docs:


### PR DESCRIPTION
## Problem

`_terraform_docs.yaml` grants `contents: write` / `pull-requests: write` to the default `GITHUB_TOKEN`, but this workflow has no steps of its own -- it only dispatches `reusable_terraform_docs.yaml` via `uses:`, passing the `APP_CLIENT_ID`/`APP_PRIVATE_KEY` secrets. The reusable workflow's own steps all authenticate with the GitHub App token, never `GITHUB_TOKEN`. This grant is unused dead privilege.

## Fix

Tighten to `permissions: {}`. Repo default workflow token permissions are "read," so an omitted block would still leak unnecessary ambient read access; `{}` is the only way to get true zero access.

Companion PRs make the equivalent fix in `reusable_terraform_docs.yaml` (`commons`) and `_terraform_docs.yaml` (`aws-bootstrap`).