### PR TITLE
refactor public subnets

### DIFF
--- a/terraform/modules/eks_vpc/data.tf
+++ b/terraform/modules/eks_vpc/data.tf
@@ -1,10 +1,1 @@
-# no state filter: keep the full, stable AZ list so transient AZ health doesn't reshuffle subnet identity
-# opt-in-status filter excludes Local/Wavelength Zones, whose names can sort before regular AZ names
-data "aws_availability_zones" "all" {
-  filter {
-    name   = "opt-in-status"
-    values = ["opt-in-not-required"]
-  }
-}
-
 data "aws_region" "current" {}

--- a/terraform/modules/eks_vpc/main.tf
+++ b/terraform/modules/eks_vpc/main.tf
@@ -1,30 +1,8 @@
 locals {
-
-  # sort availability_zones
-  availability_zones_sorted = sort(data.aws_availability_zones.all.names)
-
-  # select the first N based on availability_zone_count
-  availability_zones_first_n = slice(local.availability_zones_sorted, 0, min(var.availability_zone_count, length(local.availability_zones_sorted)))
-
-  # aws_account_id = data.aws_caller_identity.current.account_id
   aws_region = data.aws_region.current.region
 
-  igw_name = "${var.namespace}-${local.aws_region}"
-  vpc_name = "${var.namespace}-${local.aws_region}"
-
-  # prefix length of the block being carved up into public subnets
-  public_cidr_block_prefix = try(tonumber(split("/", var.public_cidr_block)[1]), null)
-
-  # additional bits needed to go from the parent block to the desired public_subnet_mask
-  public_subnet_newbits = try(var.public_subnet_mask - local.public_cidr_block_prefix, null)
-
-  # false when public_cidr_block/public_subnet_mask are malformed; variable validation already
-  # reports that case, so no public subnets are planned rather than crashing on garbage inputs
-  public_cidr_valid = local.public_subnet_newbits != null && can(cidrsubnet(var.public_cidr_block, local.public_subnet_newbits, 0))
-
-  # one public subnet per selected availability zone, keyed by AZ name for stable addressing
-  public_subnets = local.public_cidr_valid ? {
-    for idx, az in local.availability_zones_first_n : az => idx
-  } : {}
-
+  igw_name                = "${var.namespace}-${local.aws_region}"
+  public_route_table_name = "${var.namespace}-public-${local.aws_region}"
+  public_subnet_name      = "${var.namespace}-public"
+  vpc_name                = "${var.namespace}-${local.aws_region}"
 }

--- a/terraform/modules/eks_vpc/outputs.tf
+++ b/terraform/modules/eks_vpc/outputs.tf
@@ -1,38 +1,3 @@
-output "data_availability_zones_all" {
-  description = "All AWS availability zones the account has access to (unfiltered by state)"
-  value       = var.verbose_output ? data.aws_availability_zones.all : null
-}
-
-output "data_aws_region_current" {
-  description = "The current AWS region data source"
-  value       = var.verbose_output ? data.aws_region.current : null
-}
-
-output "local_availability_zones_first_n" {
-  description = "The first N availability zones based on availability_zone_count"
-  value       = var.verbose_output ? local.availability_zones_first_n : null
-}
-
-output "local_availability_zones_sorted" {
-  description = "The sorted availability zones"
-  value       = var.verbose_output ? local.availability_zones_sorted : null
-}
-
-output "local_public_subnets" {
-  description = "Map of availability zone to CIDR sub-block index used to carve each public subnet"
-  value       = var.verbose_output ? local.public_subnets : null
-}
-
-output "local_public_cidr_block_prefix" {
-  description = "The prefix length of the parent public_cidr_block (not the carved subnets' prefix)"
-  value       = var.verbose_output ? local.public_cidr_block_prefix : null
-}
-
-output "local_public_subnet_newbits" {
-  description = "The number of new bits for the local public subnets"
-  value       = var.verbose_output ? local.public_subnet_newbits : null
-}
-
 output "public_route_table_id" {
   description = "The ID of the shared public route table"
   value       = aws_route_table.public.id

--- a/terraform/modules/eks_vpc/public_route_table.tf
+++ b/terraform/modules/eks_vpc/public_route_table.tf
@@ -2,7 +2,7 @@ resource "aws_route_table" "public" {
   vpc_id = aws_vpc.vpc.id
 
   tags = {
-    Name = "${var.namespace}-public"
+    Name = local.public_route_table_name
   }
 }
 

--- a/terraform/modules/eks_vpc/public_subnets.tf
+++ b/terraform/modules/eks_vpc/public_subnets.tf
@@ -1,13 +1,13 @@
 resource "aws_subnet" "public" {
-  for_each = local.public_subnets
+  for_each = var.public_subnets
 
   availability_zone       = each.key
-  cidr_block              = cidrsubnet(var.public_cidr_block, local.public_subnet_newbits, each.value)
+  cidr_block              = each.value
   map_public_ip_on_launch = false
   vpc_id                  = aws_vpc.vpc.id
 
   tags = {
-    Name                     = "${var.namespace}-public-${each.key}"
+    Name                     = "${local.public_subnet_name}-${each.key}"
     "kubernetes.io/role/elb" = "1"
   }
 }

--- a/terraform/modules/eks_vpc/variables.tf
+++ b/terraform/modules/eks_vpc/variables.tf
@@ -1,74 +1,56 @@
-variable "availability_zone_count" {
-  description = "The number of availability zones to use for the VPC."
-  type        = number
-  default     = 3
-
-  # these subnets are ALB-only, and AWS requires ALB subnets to span at least 2 AZs
-  validation {
-    condition     = var.availability_zone_count == floor(var.availability_zone_count) && var.availability_zone_count >= 2
-    error_message = "availability_zone_count must be a whole number of at least 2."
-  }
-}
-
 variable "log_bucket_arn" {
   description = "ARN of the S3 bucket to store logs"
   type        = string
 }
 
 variable "namespace" {
+  default     = "eks"
   description = "The namespace for the VPC."
   type        = string
+
 }
 
-variable "public_cidr_block" {
-  description = "The CIDR block to carve up into public subnets, one per availability zone."
-  type        = string
+variable "public_subnets" {
+  description = "Map of availability zones to public subnet CIDR blocks."
+  type        = map(string)
 
   validation {
-    condition     = can(cidrhost(var.public_cidr_block, 0))
-    error_message = "Must be a valid IPv4 CIDR block format."
+    condition     = length(var.public_subnets) >= 2
+    error_message = "public_subnets must contain subnets in at least two availability zones."
   }
 
   validation {
-    condition = try(
-      tonumber(split("/", var.public_cidr_block)[1]) >= tonumber(split("/", var.vpc_cidr_block)[1]) &&
-      cidrhost(var.vpc_cidr_block, 0) == cidrhost("${cidrhost(var.public_cidr_block, 0)}/${split("/", var.vpc_cidr_block)[1]}", 0),
-      false
-    )
-    error_message = "public_cidr_block must be contained within vpc_cidr_block."
+    condition = alltrue([
+      for cidr in values(var.public_subnets) : try(
+        tonumber(split("/", cidr)[1]) > tonumber(split("/", var.vpc_cidr_block)[1]) &&
+        tonumber(split("/", cidr)[1]) >= 16 &&
+        tonumber(split("/", cidr)[1]) <= 27 &&
+        cidrhost(var.vpc_cidr_block, 0) == cidrhost("${cidrhost(cidr, 0)}/${split("/", var.vpc_cidr_block)[1]}", 0),
+        false
+      )
+    ])
+    error_message = "Each public subnet must be a valid /16 through /27 CIDR contained within vpc_cidr_block."
   }
-}
 
-variable "public_subnet_mask" {
-  description = "The subnet mask (prefix length) used when carving public_cidr_block into individual public subnets, e.g. 24 for a /24."
-  type        = number
-
+  # pairwise-compares network address ranges (as 32-bit integers) so overlaps are caught
+  # even between subnets with different prefix lengths or duplicate CIDRs on distinct AZ keys
   validation {
-    condition = try(
-      var.public_subnet_mask > tonumber(split("/", var.public_cidr_block)[1]) &&
-      can(cidrsubnet(var.public_cidr_block, var.public_subnet_mask - tonumber(split("/", var.public_cidr_block)[1]), 0)),
-      false
-    )
-    error_message = "Must be a valid prefix length (1-32) that is strictly more specific than public_cidr_block."
+    condition = try(alltrue([
+      for pair in setproduct(
+        [for idx, cidr in values(var.public_subnets) : {
+          idx   = idx
+          start = sum([for i, o in split(".", cidrhost(cidr, 0)) : tonumber(o) * pow(256, 3 - i)])
+          end   = sum([for i, o in split(".", cidrhost(cidr, 0)) : tonumber(o) * pow(256, 3 - i)]) + pow(2, 32 - tonumber(split("/", cidr)[1])) - 1
+        }],
+        [for idx, cidr in values(var.public_subnets) : {
+          idx   = idx
+          start = sum([for i, o in split(".", cidrhost(cidr, 0)) : tonumber(o) * pow(256, 3 - i)])
+          end   = sum([for i, o in split(".", cidrhost(cidr, 0)) : tonumber(o) * pow(256, 3 - i)]) + pow(2, 32 - tonumber(split("/", cidr)[1])) - 1
+        }]
+      ) : pair[0].idx == pair[1].idx || pair[0].start > pair[1].end || pair[1].start > pair[0].end
+    ]), false)
+    error_message = "public_subnets CIDR blocks must not overlap with one another."
   }
-
-  # AWS allows a public subnet to be between /16 and /28
-  # AWS requires ALB subnets to be /27 or larger (a /28 only has 11 usable IPs after AWS's reserved 5)
-  validation {
-    condition     = var.public_subnet_mask >= 16 && var.public_subnet_mask <= 27
-    error_message = "public_subnet_mask must be between 16 and 27; these subnets are ALB-only and AWS requires /27 or larger for ALB subnets."
-  }
-
-  validation {
-    condition     = try(pow(2, var.public_subnet_mask - tonumber(split("/", var.public_cidr_block)[1])) >= var.availability_zone_count, false)
-    error_message = "public_subnet_mask must be small enough to carve out at least availability_zone_count sub-blocks from public_cidr_block."
-  }
-}
-
-variable "verbose_output" {
-  description = "Enable verbose output for debugging purposes."
-  type        = bool
-  default     = false
 }
 
 variable "vpc_cidr_block" {
@@ -88,5 +70,4 @@ variable "vpc_cidr_block" {
     ])
     error_message = "The VPC CIDR block must reside in private IP space."
   }
-
 }

--- a/terragrunt/aws/mgmt/us-east-2/eks_vpc/terragrunt.hcl
+++ b/terragrunt/aws/mgmt/us-east-2/eks_vpc/terragrunt.hcl
@@ -16,10 +16,7 @@ dependency "log_bucket" {
 }
 
 inputs = {
-  log_bucket_arn     = dependency.log_bucket.outputs.log_bucket_arn
-  namespace          = "eks"
-  public_cidr_block  = "10.1.32.0/21"
-  public_subnet_mask = 23
-  verbose_output     = true
-  vpc_cidr_block     = "10.1.32.0/19" # region block 2 of 8: 10.1.0.0/16 split into 8 /19s
+  log_bucket_arn = dependency.log_bucket.outputs.log_bucket_arn
+  public_subnets = include.root.locals.merged_vars.eks_public_subnets
+  vpc_cidr_block = include.root.locals.merged_vars.eks_vpc_cidr_block
 }

--- a/terragrunt/aws/mgmt/us-east-2/region.hcl
+++ b/terragrunt/aws/mgmt/us-east-2/region.hcl
@@ -1,5 +1,12 @@
 locals {
   aws_region = "us-east-2"
 
+  eks_public_subnets = { # public subnet block 10.1.32.0/21
+    "us-east-2a" = "10.1.32.0/23"
+    "us-east-2b" = "10.1.34.0/23"
+    "us-east-2c" = "10.1.36.0/23"
+  }
+  eks_vpc_cidr_block = "10.1.32.0/19" # region block 2 of 8: 10.1.0.0/16 split into 8 /19s
+
   enable_cloudtrail_logs = true
 }


### PR DESCRIPTION
Refactor module so the public subnets are input via map specifying the availability zone and the associated cidr block for each public subnet.

Add a default to the namespace variable.

Move the definition of the public subnets and vpc cidr block variables to the region hcl for us-east-2.

Clean-up code no longer necessary.